### PR TITLE
excluded com.gargoylesoftware.css.parser from jacoco

### DIFF
--- a/mariotti-project/pom.xml
+++ b/mariotti-project/pom.xml
@@ -338,6 +338,7 @@
 							<excludes>
 								<exclude>**/*Application.*</exclude>
 								<exclude>**/models/*</exclude>
+								<exclude>**com.gargoylesoftware.css.parser*</exclude>
 							</excludes>
 						</configuration>
 						<executions>


### PR DESCRIPTION
it caused an MethodTooLargeException